### PR TITLE
docs: Fix update_spool REST URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Add the following to your `configuration.yaml` to create a REST command that upd
 ```yaml
 rest_command:
   update_spool:
-    url: "http://<your-server>:8088/Spools/spool"
+    url: "http://<your-server>:8088/Spools"
     method: POST
     headers:
       Content-Type: "application/json"


### PR DESCRIPTION
After looking at the Swagger and running into various 404, I believe the URL in the docs are currently wrong.